### PR TITLE
Fixed configuration dump typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ $(call say,"Running configuration")
 @ echo "    TIMEZONE   = $(TIMEZONE)"
 @ echo "    REPO_URL   = $(REPO_URL)"
 @ echo "    PIKVM_REPO_URL   = $(PIKVM_REPO_URL)"
-@ echo "    PIKVM_REPO_KEY   = $(PIKVM_REPO_URL)"
+@ echo "    PIKVM_REPO_KEY   = $(PIKVM_REPO_KEY)"
 @ echo
 @ echo "    CARD = $(CARD)"
 @ echo


### PR DESCRIPTION
Configuration dump showed URL twice instead of URL and REPO_KEY.
This fixes the output.