### PR TITLE
Use official archlinux base image

### DIFF
--- a/toolbox/Dockerfile.root
+++ b/toolbox/Dockerfile.root
@@ -1,4 +1,4 @@
-FROM archlinux:base-devel
+FROM archlinux/archlinux:base-devel
 
 RUN mkdir -p /etc/pacman.d/hooks \
 	&& ln -s /dev/null /etc/pacman.d/hooks/30-systemd-tmpfiles.hook

--- a/toolbox/Dockerfile.root
+++ b/toolbox/Dockerfile.root
@@ -1,11 +1,10 @@
-FROM archlinux/base
+FROM archlinux:base-devel
 
 RUN mkdir -p /etc/pacman.d/hooks \
 	&& ln -s /dev/null /etc/pacman.d/hooks/30-systemd-tmpfiles.hook
 
 RUN pacman --noconfirm -Syu \
 	&& pacman --needed --noconfirm -S \
-		base-devel \
 		arp-scan \
 		python \
 		parted \


### PR DESCRIPTION
The archlinux/base image is deprecated and will be removed by April 2021:
https://gitlab.archlinux.org/archlinux/archlinux-docker/-/issues/46

The official image is now [archlinux/archlinux](https://hub.docker.com/r/archlinux/archlinux), which is updated daily. It is also published in the docker hub library as offical image, updated once a week. May I suggest to use the more recent community version?

There also is a base-devel tag, that includes the base-devel packages. This might give a little speedup here.

I also found [other usages of archlinux/base in pikvm repos](https://github.com/search?q=org%3Apikvm+archlinux%2Fbase&type=code), but since I'm only using pi-builder, I'm opening a pull request here.