### PR TITLE
Dirmngr resolver fix

### DIFF
--- a/stages/pikvm-repo/Dockerfile.part
+++ b/stages/pikvm-repo/Dockerfile.part
@@ -1,8 +1,8 @@
 RUN ( \
-		mkdir -p -m 0700 $HOME/.gnupg \
-		&& echo standard-resolver >> $HOME/.gnupg/dirmngr.conf
-		pacman-key --keyserver hkps://hkps.pool.sks-keyservers.net -r $PIKVM_REPO_KEY \
-		|| pacman-key --keyserver keyserver.ubuntu.com -r $PIKVM_REPO_KEY \
+		mkdir -p /etc/gnupg \
+		&& echo standard-resolver >> /etc/gnupg/dirmngr.conf \
+		&& ( pacman-key --keyserver hkps://hkps.pool.sks-keyservers.net -r $PIKVM_REPO_KEY \
+		|| pacman-key --keyserver keyserver.ubuntu.com -r $PIKVM_REPO_KEY ) \
 	) \
 	&& pacman-key --lsign-key $PIKVM_REPO_KEY \
 	&& echo -e "\n[pikvm]" >> /etc/pacman.conf \

--- a/stages/pikvm-repo/Dockerfile.part
+++ b/stages/pikvm-repo/Dockerfile.part
@@ -1,4 +1,6 @@
 RUN ( \
+		mkdir -p -m 0700 $HOME/.gnupg \
+		&& echo standard-resolver >> $HOME/.gnupg/dirmngr.conf
 		pacman-key --keyserver hkps://hkps.pool.sks-keyservers.net -r $PIKVM_REPO_KEY \
 		|| pacman-key --keyserver keyserver.ubuntu.com -r $PIKVM_REPO_KEY \
 	) \


### PR DESCRIPTION
Systems using `systemd-resolved` by default, such as Ubuntu 20.10 and Arch Linux, may fail to resolve the hostnames of the keyservers. While Docker will identify `systemd-resolved` and will set Google's DNS servers (`8.8.8.8` and `8.8.4.4`), this does not seem to fix the build and neither does setting the resolvers in `/etc/docker/daemon.json`.

This fixes the builds where `pacman-key` fails to pull the pikvm repo gpg keys due to this configuration by informing it to use `standard-resolver` for DNS lookups.