### PR TITLE
Update Dockerfile.part

### DIFF
--- a/stages/os/Dockerfile.part
+++ b/stages/os/Dockerfile.part
@@ -10,7 +10,7 @@ RUN rm -f /etc/localtime \
 RUN echo "HOOKS=(base udev block filesystems)" >> /etc/mkinitcpio.conf
 
 RUN sed -i -e "s|\<root=/dev/mmcblk0p2\>|root=LABEL=PIROOT|g" /boot/cmdline.txt
-RUN sed -i -e "s|^/dev/mmcblk0p1\>|LABEL=PIBOOT|g" /etc/fstab
+RUN sed -i -e "s|^/dev/mmcblk0p1|LABEL=PIBOOT|g" /etc/fstab
 
 RUN echo "Server = $REPO_URL/\$arch/\$repo" > /etc/pacman.d/mirrorlist \
 	&& pacman-key --init \


### PR DESCRIPTION
This sed command will not replace /dev/mmcblk0p1 with LABEL=PIBOOT because the original sed command is replacing  /dev/mmcblk0p1> with LABEL=PIBOOT and that string doesn't exist in /etc/fstab.