### PR TITLE
Fixing toolbox

### DIFF
--- a/toolbox/Dockerfile.root
+++ b/toolbox/Dockerfile.root
@@ -1,4 +1,4 @@
-FROM archlinux/archlinux:base-devel
+FROM archlinux/archlinux:base
 
 RUN mkdir -p /etc/pacman.d/hooks \
 	&& ln -s /dev/null /etc/pacman.d/hooks/30-systemd-tmpfiles.hook

--- a/toolbox/Dockerfile.root
+++ b/toolbox/Dockerfile.root
@@ -7,7 +7,6 @@ RUN pacman --noconfirm --ask=4 -Syy \
 	&& pacman --needed --noconfirm --ask=4 -S \
 		glibc \
 		openssl \
-		openssl-1.0 \
 		openssl-1.1 \
 	&& pacman --needed --noconfirm --ask=4 -S \
 		pacman \


### PR DESCRIPTION
Had to remove openssl from build env since it is currently not found by pacman.

also changed from base-devel to base since
https://hub.docker.com/r/base/devel
claims its deprecated