### PR TITLE
Remove /run mount in fstab to prevent auto remounts

### DIFF
--- a/stages/ro/fstab
+++ b/stages/ro/fstab
@@ -6,4 +6,3 @@ tmpfs /var/lib/dhcpcd    tmpfs  mode=0750               0 0
 tmpfs /var/log           tmpfs  nodev,nosuid            0 0
 tmpfs /var/tmp           tmpfs  nodev,nosuid            0 0
 tmpfs /tmp               tmpfs  nodev,nosuid,mode=1777  0 0
-tmpfs /run               tmpfs  noauto,nodev,nosuid,mode=0755  0 0

--- a/stages/ro/fstab
+++ b/stages/ro/fstab
@@ -6,4 +6,4 @@ tmpfs /var/lib/dhcpcd    tmpfs  mode=0750               0 0
 tmpfs /var/log           tmpfs  nodev,nosuid            0 0
 tmpfs /var/tmp           tmpfs  nodev,nosuid            0 0
 tmpfs /tmp               tmpfs  nodev,nosuid,mode=1777  0 0
-tmpfs /run               tmpfs  nodev,nosuid,mode=0755  0 0
+tmpfs /run               tmpfs  noauto,nodev,nosuid,mode=0755  0 0


### PR DESCRIPTION
Auto remounts of `/run` when executing programs cause corruptions.

Material: PiKVM 4 Plus (probably same with others)

The issue was:
- Broken systemd, saying not executed at the boot and not PID 1 (even it is)
- Broken Janus, who progressively use 100% of the CPU (after 5 minutes and more)
- Hard rebooting in this condition can break the boot sequence
- Probably other issues...

Steps to reproduce:
Flash the image on sd card
Go to the terminal in root
Make writable with `rw`
Edit `/etc/fstab` to add an USB stick mount point (maybe optional)
Run `mount -a`
Try to use systemd, `cat /etc/resolv.conf`, `ping google.com` or monitor janus...


![image](https://github.com/pikvm/pi-builder/assets/34275555/e36e21da-6d3b-40d3-8952-2ffcfbc6b35b)
![image](https://github.com/pikvm/pi-builder/assets/34275555/90c54a9d-c145-46bb-ad58-31e28692a498)
![image](https://github.com/pikvm/pi-builder/assets/34275555/1c228de3-2923-4a8c-a082-b7de9dd1f5e9)
