### PR TITLE
Add initial update to prevent pacman lib version issue

### DIFF
--- a/stages/arch/os/Dockerfile.part
+++ b/stages/arch/os/Dockerfile.part
@@ -17,6 +17,7 @@ RUN cp /etc/pacman.d/mirrorlist /tmp/pacman.mirrorlist.saved \
 RUN sed -i -e "s/^CheckSpace/#!!!CheckSpace/g" /etc/pacman.conf
 
 RUN pacman --noconfirm --ask=4 -Syy \
+	&& pacman --noconfirm --ask=4 -Syu \
 	&& pacman --needed --noconfirm --ask=4 -S \
 		glibc \
 		openssl \


### PR DESCRIPTION
An issue was being thrown during build due to some lib's version misalignment (see below the logs). An extra update at the beginning prevents that issue.

```bash
24.48 :: Processing package changes...
24.48 upgrading gpgme...
24.62 upgrading pacman...
24.80 warning: /etc/pacman.conf installed as /etc/pacman.conf.pacnew
25.06 New optional dependencies for pacman
25.06     base-devel: required to use makepkg
25.15 :: Running post-transaction hooks...
25.15 (1/3) Creating system user accounts...
25.27 Creating group 'alpm' with GID 973.
25.27 Creating user 'alpm' (Arch Linux Package Management) with UID 973 and GID 973.
25.32 (2/3) Reloading system manager configuration...
25.41   Skipped: Current root is not booted.
25.41 (3/3) Arming ConditionNeedsUpdate...
25.73 /usr/sbin/pacman-conf: error while loading shared libraries: libassuan.so.9: cannot open shared object file: No such file or directory
```