### PR TITLE
Don't install openssl-1.1 which no longer exists

### DIFF
--- a/stages/arch/os/Dockerfile.part
+++ b/stages/arch/os/Dockerfile.part
@@ -20,7 +20,6 @@ RUN sed -i -e "s/^#DisableSandbox/DisableSandbox/g" /etc/pacman.conf
 RUN pacman --noconfirm --ask=4 -Syu \
 	&& pacman --needed --noconfirm --ask=4 -S \
 		openssl \
-		openssl-1.1 \
 		p11-kit \
 		archlinux-keyring \
 		ca-certificates \

--- a/toolbox/Dockerfile.common
+++ b/toolbox/Dockerfile.common
@@ -4,7 +4,6 @@ RUN sed -i -e "s/^#DisableSandbox/DisableSandbox/g" /etc/pacman.conf
 RUN pacman --noconfirm --ask=4 -Syu \
 	&& pacman --needed --noconfirm --ask=4 -S \
 		openssl \
-		openssl-1.1 \
 		p11-kit \
 		archlinux-keyring \
 		ca-certificates \


### PR DESCRIPTION
Arch Linux ARM have dropped openssl-1.1 packages - it seems they moved to OpenSSL 3.x in 2022 so hopefully everything has updated by now.  This PR stops installing them - tested and everything seems to work as normal.

Also, sidenote: https://github.com/pikvm/os/blob/master/Makefile#L75 is cloning the github.com/mdevaev/pi-builder repo not this one. Not sure this matters much as you keep them in sync, but thought it could be a source of surprises worth commenting on.
